### PR TITLE
fix(qt_display): map channel_id to label index and wait for UI ready

### DIFF
--- a/element/tools/qt_display/include/qt_display.h
+++ b/element/tools/qt_display/include/qt_display.h
@@ -4,6 +4,8 @@
 #include <QLoggingCategory>
 #include <QSharedPointer>
 #include <atomic>
+#include <condition_variable>
+#include <mutex>
 #include <unordered_set>
 
 #include "BMLabel.h"
@@ -44,9 +46,14 @@ class QtDisplay : public ::sophon_stream::framework::Element {
 
   std::thread qt_thread;
 
+  std::mutex ui_mutex;
+  std::condition_variable ui_cv;
+  std::atomic<bool> ui_ready{false};
+
   // 停止qt的条件
   std::mutex channel_mutex;
   std::unordered_set<int> channel_ids;
+  std::unordered_map<int, int> channel_id_to_label_idx;
   std::atomic<int> stopped_num;
 
   // std::vector<::sophon_stream::common::FpsProfiler*> mFpsProfilers;

--- a/element/tools/qt_display/src/qt_display.cc
+++ b/element/tools/qt_display/src/qt_display.cc
@@ -51,6 +51,12 @@ int QtDisplay::qt_func() {
   qwidget_ptr->setLayout(layout);
   qwidget_ptr->show();
 
+  {
+    std::lock_guard<std::mutex> lock(ui_mutex);
+    ui_ready = true;
+  }
+  ui_cv.notify_all();
+
   return qapp->exec();
 }
 
@@ -64,9 +70,18 @@ common::ErrorCode QtDisplay::initInternal(const std::string& json) {
   rows = configure.find(CONFIG_INTERNAL_ROWS)->get<int>();
   cols = configure.find(CONFIG_INTERNAL_COLS)->get<int>();
   stopped_num = 0;
+  ui_ready = false;
 
   qt_thread = std::thread(&QtDisplay::qt_func, this);
-  std::this_thread::sleep_for(std::chrono::seconds(1));
+  {
+    std::unique_lock<std::mutex> lock(ui_mutex);
+    ui_cv.wait_for(lock, std::chrono::seconds(10),
+                   [this] { return ui_ready.load(); });
+  }
+  if (!ui_ready.load()) {
+    IVS_WARN("qt display ui init timeout");
+    return common::ErrorCode::UNKNOWN;
+  }
 
   thread_num = getThreadNumber();
 
@@ -92,18 +107,37 @@ common::ErrorCode QtDisplay::doWork(int dataPipeId) {
   auto objectMetadata = std::static_pointer_cast<common::ObjectMetadata>(data);
 
   int channel_id = objectMetadata->mFrame->mChannelIdInternal;
-  if (channel_ids.find(channel_id) == channel_ids.end()) {
+  int label_idx = 0;
+  {
     std::unique_lock<std::mutex> lock(channel_mutex);
-    channel_ids.insert(channel_id);
+    auto it = channel_id_to_label_idx.find(channel_id);
+    if (it == channel_id_to_label_idx.end()) {
+      label_idx = static_cast<int>(channel_id_to_label_idx.size());
+      channel_id_to_label_idx[channel_id] = label_idx;
+      channel_ids.insert(channel_id);
+    } else {
+      label_idx = it->second;
+    }
   }
   auto bmimg_ptr = objectMetadata->mFrame->mSpDataOsd;
 
   if (bmimg_ptr == nullptr) bmimg_ptr = objectMetadata->mFrame->mSpData;
 
-  if (objectMetadata->mFrame->mEndOfStream)
+  if (objectMetadata->mFrame->mEndOfStream) {
     stopped_num++;
-  else
-    label_vec[channel_id]->show_img(bmimg_ptr);
+  } else {
+    if (!ui_ready.load()) {
+      std::unique_lock<std::mutex> lock(ui_mutex);
+      ui_cv.wait_for(lock, std::chrono::seconds(10),
+                     [this] { return ui_ready.load(); });
+    }
+    if (label_idx < static_cast<int>(label_vec.size()))
+      label_vec[label_idx]->show_img(bmimg_ptr);
+    else
+      IVS_WARN(
+          "label index {0:d} exceeds label count {1:d} for channel {2:d}",
+          label_idx, label_vec.size(), channel_id);
+  }
 
   if (stopped_num == channel_ids.size()) qapp->quit();
 

--- a/samples/yolox_bytetrack_osd_qt/config/osd.json
+++ b/samples/yolox_bytetrack_osd_qt/config/osd.json
@@ -1,7 +1,7 @@
 {
   "configure": {
     "osd_type": "TRACK",
-    "class_names_file": "../yolox_bytetrack_osd_encode/data/coco.names",
+    "class_names_file": "../yolox_bytetrack_osd_qt/data/coco.names",
     "draw_utils": "OPENCV",
     "draw_interval": false,
     "put_text": false


### PR DESCRIPTION
## Summary
- Fix segfault in `qt_display` when `channel_id` is not a contiguous index (e.g. 2, 3, 20, 30)
- Wait for Qt widgets to be fully created before displaying frames, avoiding race-condition warnings
- Fix `class_names_file` path in `yolox_bytetrack_osd_qt` sample `osd.json`

## Problem
Running `run_hdmi_show.sh` caused `Segmentation fault` because `label_vec[channel_id]` was out of bounds.
After adding bounds check, warnings like `label index X exceeds label count 0` appeared due to UI init race.

## Test plan
- [x] Rebuilt `libqt_display.so` on SoC platform
- [x] Ran `sudo ./run_hdmi_show.sh` with 4 video channels
- [x] No segfault, no label index warnings, video displays correctly